### PR TITLE
Use auth helpers to create server supabase client

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -2,12 +2,21 @@ import type { LoaderArgs } from '@remix-run/node';
 
 import { useLoaderData } from '@remix-run/react';
 import { Login } from 'components/login';
-import supabase from 'utils/supabase.server';
+import { createServerClient } from '@supabase/auth-helpers-remix';
 
-export const loader = async ({}: LoaderArgs) => {
-	const { data } = await supabase.from('messages').select('*');
+export const loader = async ({ request }: LoaderArgs) => {
+  const response = new Response();
+  const supabase = createServerClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_ANON_KEY!,
+    {
+      request,
+      response,
+    }
+  );
+  const { data } = await supabase.from("messages").select("*");
 
-	return { messages: data ?? [] };
+  return { messages: data ?? [], headers: response.headers };
 };
 
 export default function Index() {


### PR DESCRIPTION
By using the auth-helpers package you configure Supabase Auth to store the user's session data in cookies, rather than localStorage. Using the auth-helpers in the Login component configures this to use cookies, however, the loader is still using `supabase-js` which uses localStorage (does not exist server-side).

This PR refactors the loader to also use the auth-helpers package so everything is using cookies! 🍪

Related to: https://stackoverflow.com/questions/75356159/supabase-oauth-with-remix-errors-on-redirect-you-are-trying-to-use-a-blocker-on/75739357#75739357